### PR TITLE
Cleanup before executing a new API request

### DIFF
--- a/plumber.R
+++ b/plumber.R
@@ -53,6 +53,12 @@ function(req, res, model_type = "shortest_path") {
   zip::zip(zipfile = zfile,
            files = paste0("hiking_output/", solution_files))
   
+  # Delete folder of output data, as it is no longer needed after the zip file is created
+  unlink("hiking_output", recursive = TRUE)
+  
+  # Also delete solution files
+  file.remove(solution_files)
+  
   readBin(zfile, "raw", n = file.info(zfile)$size)
   
 }


### PR DESCRIPTION
If the cloud run server is still warm and has not shut down, remove files from a previous API request before running the current API request.